### PR TITLE
build:重构依赖管理并添加 JarRelocator 支持

### DIFF
--- a/MHDF-Tools-Bukkit/pom.xml
+++ b/MHDF-Tools-Bukkit/pom.xml
@@ -40,6 +40,52 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.alibaba</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.com.alibaba</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.reflections</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.org.reflections</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.javassist</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.org.javassist</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.github.retrooper</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.com.github.retrooper</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>de.tr7zw</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.de.tr7zw</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.j256.ormlite</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.com.j256.ormlite</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.zaxxer</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.com.zaxxer</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.h2database</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.com.h2database</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.mysql</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.com.mysql</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.lettuce</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.io.lettuce</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.kyori</pattern>
+                                    <shadedPattern>cn.chengzhiya.mhdftools.libraries.net.kyori</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <minimizeJar>true</minimizeJar>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>

--- a/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/libraries/Dependency.java
+++ b/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/libraries/Dependency.java
@@ -8,7 +8,7 @@ import java.util.Locale;
 public enum Dependency {
     // JSON处理
     FAST_JSON(
-            "com.alibaba",
+            "com{}alibaba",
             "fastjson",
             "1.2.83",
             Repository.MAVEN_CENTRAL_MIRROR
@@ -16,13 +16,13 @@ public enum Dependency {
 
     // 反射处理
     REFLECTIONS(
-            "org.reflections",
+            "org{}reflections",
             "reflections",
             "0.10.2",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     JAVASSITST(
-            "org.javassist",
+            "org{}javassist",
             "javassist",
             "3.28.0-GA",
             Repository.MAVEN_CENTRAL_MIRROR
@@ -30,19 +30,19 @@ public enum Dependency {
 
     // packetevents-api
     PACKETEVENTS_API(
-            "com.github.retrooper",
+            "com{}github{}retrooper",
             "packetevents-api",
             "2.6.0",
             Repository.CODE_MC
     ),
     PACKETEVENTS_NETTY_COMMON(
-            "com.github.retrooper",
+            "com{}github{}retrooper",
             "packetevents-netty-common",
             "2.6.0",
             Repository.CODE_MC
     ),
     PACKETEVENTS_SPIGOT(
-            "com.github.retrooper",
+            "com{}github{}retrooper",
             "packetevents-spigot",
             "2.6.0",
             Repository.CODE_MC
@@ -50,7 +50,7 @@ public enum Dependency {
 
     // item-nbt-api
     ITEM_NBT_API(
-            "de.tr7zw",
+            "de{}tr7zw",
             "item-nbt-api",
             "2.14.1",
             Repository.CODE_MC
@@ -58,31 +58,31 @@ public enum Dependency {
 
     // 数据库
     ORMLITE_CORE(
-            "com.j256.ormlite",
+            "com{}j256{}ormlite",
             "ormlite-core",
             "6.1",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ORMLITE_JDBC(
-            "com.j256.ormlite",
+            "com{}j256{}ormlite",
             "ormlite-jdbc",
             "6.1",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     HIKARI_CP(
-            "com.zaxxer",
+            "com{}zaxxer",
             "HikariCP",
             "6.1.0",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     H2_DRIVER(
-            "com.h2database",
+            "com{}h2database",
             "h2",
             "2.3.232",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     MYSQL_DRIVER(
-            "com.mysql",
+            "com{}mysql",
             "mysql-connector-j",
             "9.1.0",
             Repository.MAVEN_CENTRAL_MIRROR
@@ -90,7 +90,7 @@ public enum Dependency {
 
     // redis
     LETTUCE_CORE(
-            "io.lettuce",
+            "io{}lettuce",
             "lettuce-core",
             "6.5.3.RELEASE",
             Repository.MAVEN_CENTRAL_MIRROR
@@ -98,81 +98,103 @@ public enum Dependency {
 
     // adventure-api
     EXAMINATION_API(
-            "net.kyori",
+            "net{}kyori",
             "examination-api",
             "1.3.0",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     EXAMINATION_STRING(
-            "net.kyori",
+            "net{}kyori",
             "examination-string",
             "1.3.0",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_KEY(
-            "net.kyori",
+            "net{}kyori",
             "adventure-key",
             "4.17.0",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_API(
-            "net.kyori",
+            "net{}kyori",
             "adventure-api",
             "4.17.0",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_TEXT_SERIALIZER_LEGACY(
-            "net.kyori",
+            "net{}kyori",
             "adventure-text-serializer-legacy",
             "4.13.1",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_TEXT_SERIALIZER_GSON(
-            "net.kyori",
+            "net{}kyori",
             "adventure-text-serializer-gson",
             "4.13.1",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_TEXT_SERIALIZER_GSON_LEGACY_IMPL(
-            "net.kyori",
+            "net{}kyori",
             "adventure-text-serializer-gson-legacy-impl",
             "4.13.1",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_TEXT_SERIALIZER_BUNGEECORD(
-            "net.kyori",
+            "net{}kyori",
             "adventure-text-serializer-bungeecord",
             "4.3.4",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_NBT(
-            "net.kyori",
+            "net{}kyori",
             "adventure-nbt",
             "4.13.1",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_PLATFORM_API(
-            "net.kyori",
+            "net{}kyori",
             "adventure-platform-api",
             "4.3.4",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_PLATFORM_FACET(
-            "net.kyori",
+            "net{}kyori",
             "adventure-platform-facet",
             "4.3.4",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_PLATFORM_VIAVERSION(
-            "net.kyori",
+            "net{}kyori",
             "adventure-platform-viaversion",
             "4.3.4",
             Repository.MAVEN_CENTRAL_MIRROR
     ),
     ADVENTURE_PLATFORM_BUKKIT(
-            "net.kyori",
+            "net{}kyori",
             "adventure-platform-bukkit",
             "4.3.4",
+            Repository.MAVEN_CENTRAL_MIRROR
+    ),
+
+    // remap必要依赖
+    ASM(
+            "org{}ow2{}asm",
+            "asm",
+            "9.7.1",
+            Repository.MAVEN_CENTRAL_MIRROR
+    ),
+
+    ASM_COMMONS(
+            "org{}ow2{}asm",
+            "asm-commons",
+            "9.7.1",
+            Repository.MAVEN_CENTRAL_MIRROR
+    ),
+
+    JAR_RELOCATOR(
+            "me{}lucko",
+            "jar-relocator",
+            "1.7",
             Repository.MAVEN_CENTRAL_MIRROR
     );
 
@@ -182,15 +204,18 @@ public enum Dependency {
     private final Repository repository;
     @Getter
     private final String mavenRepoPath;
+    @Getter
+    private final String groupId;
 
     Dependency(@NotNull String groupId, @NotNull String artifactId, @NotNull String version, @NotNull Repository repository) {
         this.mavenRepoPath = String.format("%s/%s/%s/%s-%s.jar",
-                groupId.replace(".", "/"),
+                groupId.replace("{}", ".").replace(".", "/"),
                 artifactId,
                 version,
                 artifactId,
                 version
         );
+        this.groupId = groupId.replace("{}", ".");
         this.version = version;
         this.repository = repository;
         this.artifact = artifactId;

--- a/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/libraries/DependencyManager.java
+++ b/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/libraries/DependencyManager.java
@@ -3,5 +3,9 @@ package cn.chengzhiya.mhdftools.libraries;
 import java.util.Collection;
 
 public interface DependencyManager {
+    void downloadDependencies(Collection<Dependency> dependencies);
+
     void loadDependencies(Collection<Dependency> dependencies);
+
+    void init();
 }

--- a/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/libraries/JarRelocator.java
+++ b/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/libraries/JarRelocator.java
@@ -1,0 +1,39 @@
+package cn.chengzhiya.mhdftools.libraries;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+public class JarRelocator {
+    private static final String JAR_RELOCATOR_CLASS = "me.lucko.jarrelocator.JarRelocator";
+    private static final String JAR_RELOCATOR_RUN_METHOD = "run";
+
+    private final Constructor<?> jarRelocatorConstructor;
+    private final Method jarRelocatorRunMethod;
+
+    public JarRelocator() {
+        try {
+            Class<?> jarRelocatorClass = Class.forName(JAR_RELOCATOR_CLASS);
+            this.jarRelocatorConstructor = jarRelocatorClass.getDeclaredConstructor(File.class, File.class, Map.class);
+            this.jarRelocatorConstructor.setAccessible(true);
+            this.jarRelocatorRunMethod = jarRelocatorClass.getDeclaredMethod(JAR_RELOCATOR_RUN_METHOD);
+            this.jarRelocatorRunMethod.setAccessible(true);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * 重新映射JAR文件中的类路径并生成新的JAR文件
+     *
+     * @param input       需要处理的目标JAR文件对象
+     * @param output      重定位后生成的JAR文件对象
+     * @param relocations 类路径重定位映射规则，键为原始路径，值为目标路径
+     * @throws Exception 可能抛出的反射操作异常或文件操作异常
+     */
+    public void remap(File input, File output, Map<String, String> relocations) throws Exception {
+        Object jarRelocator = this.jarRelocatorConstructor.newInstance(input, output, relocations);
+        this.jarRelocatorRunMethod.invoke(jarRelocator);
+    }
+}

--- a/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/manager/LibrariesManager.java
+++ b/MHDF-Tools-Bukkit/src/main/java/cn/chengzhiya/mhdftools/manager/LibrariesManager.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 @SuppressWarnings("unused")
 public final class LibrariesManager implements Init {
+    public static final List<Dependency> DEPENDENCIES = List.of(Dependency.ASM, Dependency.ASM_COMMONS, Dependency.JAR_RELOCATOR);
+
     /**
      * 下载并加载所有所需依赖
      */
@@ -20,6 +22,9 @@ public final class LibrariesManager implements Init {
                 new ReflectionClassPathAppender(Main.class.getClassLoader())
         );
 
+        dependencyManager.downloadDependencies(List.of(Dependency.values()));
+        dependencyManager.loadDependencies(DEPENDENCIES); // 加载remap依赖
+        dependencyManager.init();
         dependencyManager.loadDependencies(List.of(Dependency.values()));
     }
 }


### PR DESCRIPTION
- 新增 JarRelocator 类以支持 JAR 文件重定位
- 重构 DependencyManager 接口，增加 downloadDependencies 和 init 方法
- 实现 DependencyManagerImpl 类，支持依赖下载和重定位
- 更新 LibrariesManager 以使用新的依赖管理功能
- 修改 pom.xml，添加重定位配置